### PR TITLE
pull request #1

### DIFF
--- a/fs_mgr/Android.mk
+++ b/fs_mgr/Android.mk
@@ -8,8 +8,8 @@ LOCAL_SRC_FILES:= fs_mgr.c fs_mgr_verity.c fs_mgr_fstab.c
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
 
 LOCAL_MODULE:= libfs_mgr
-LOCAL_STATIC_LIBRARIES := liblogwrap libmincrypt libext4_utils_static
-LOCAL_C_INCLUDES += system/extras/ext4_utils
+LOCAL_STATIC_LIBRARIES := liblogwrap libmincrypt libext4_utils_static libext2_blkid libext2_uuid
+LOCAL_C_INCLUDES += system/extras/ext4_utils external/e2fsprogs/lib
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
 LOCAL_CFLAGS := -Werror
 
@@ -30,7 +30,7 @@ LOCAL_FORCE_STATIC_EXECUTABLE := true
 LOCAL_MODULE_PATH := $(TARGET_ROOT_OUT)/sbin
 LOCAL_UNSTRIPPED_PATH := $(TARGET_ROOT_OUT_UNSTRIPPED)
 
-LOCAL_STATIC_LIBRARIES := libfs_mgr liblogwrap libcutils liblog libc libmincrypt libext4_utils_static
+LOCAL_STATIC_LIBRARIES := libfs_mgr liblogwrap libcutils liblog libc libmincrypt libext4_utils_static libext2_blkid libext2_uuid
 
 LOCAL_CFLAGS := -Werror
 

--- a/fs_mgr/fs_mgr.c
+++ b/fs_mgr/fs_mgr.c
@@ -35,6 +35,7 @@
 #include <cutils/partition_utils.h>
 #include <cutils/properties.h>
 #include <logwrap/logwrap.h>
+#include <blkid/blkid.h>
 
 #include "mincrypt/rsa.h"
 #include "mincrypt/sha.h"
@@ -261,6 +262,8 @@ static int mount_with_alternatives(struct fstab *fstab, int start_idx, int *end_
     int i;
     int mount_errno = 0;
     int mounted = 0;
+    int cmp_len;
+    char *detected_fs_type;
 
     if (!end_idx || !attempted_idx || start_idx >= fstab->num_entries) {
       errno = EINVAL;
@@ -286,8 +289,16 @@ static int mount_with_alternatives(struct fstab *fstab, int start_idx, int *end_
             }
 
             if (fstab->recs[i].fs_mgr_flags & MF_CHECK) {
-                check_fs(fstab->recs[i].blk_device, fstab->recs[i].fs_type,
-                         fstab->recs[i].mount_point);
+                /* Skip file system check unless we are sure we are the right type */
+                detected_fs_type = blkid_get_tag_value(NULL, "TYPE", fstab->recs[i].blk_device);
+                if (detected_fs_type) {
+                    cmp_len = (!strncmp(detected_fs_type, "ext", 3) &&
+                            strlen(detected_fs_type) == 4) ? 3 : strlen(detected_fs_type);
+                    if (!strncmp(fstab->recs[i].fs_type, detected_fs_type, cmp_len)) {
+                        check_fs(fstab->recs[i].blk_device, fstab->recs[i].fs_type,
+                                 fstab->recs[i].mount_point);
+                    }
+                }
             }
             if (!__mount(fstab->recs[i].blk_device, fstab->recs[i].mount_point, &fstab->recs[i])) {
                 *attempted_idx = i;

--- a/init/Android.mk
+++ b/init/Android.mk
@@ -45,7 +45,9 @@ LOCAL_STATIC_LIBRARIES := \
 	libc \
 	libselinux \
 	libmincrypt \
-	libext4_utils_static
+	libext4_utils_static \
+	libext2_blkid \
+	libext2_uuid
 
 LOCAL_ADDITIONAL_DEPENDENCIES += $(LOCAL_PATH)/Android.mk
 

--- a/init/builtins.c
+++ b/init/builtins.c
@@ -254,9 +254,35 @@ int do_enable(int nargs, char **args)
     return 0;
 }
 
+#define MAX_PARAMETERS 64
 int do_exec(int nargs, char **args)
 {
-    return -1;
+    pid_t pid;
+    int status, i, j;
+    char *par[MAX_PARAMETERS];
+
+    if (nargs > MAX_PARAMETERS)
+    {
+        return -1;
+    }
+
+    for(i=0, j=1; i<(nargs-1) ;i++,j++)
+    {
+        par[i] = args[j];
+    }
+
+    par[i] = (char*)0;
+    pid = fork();
+    if (!pid)
+    {
+        execv(par[0],par);
+    }
+    else
+    {
+        while(wait(&status)!=pid);
+    }
+
+    return 0;
 }
 
 int do_export(int nargs, char **args)

--- a/init/devices.c
+++ b/init/devices.c
@@ -54,6 +54,7 @@
 #define FIRMWARE_DIR1   "/etc/firmware"
 #define FIRMWARE_DIR2   "/vendor/firmware"
 #define FIRMWARE_DIR3   "/firmware/image"
+#define DEVICES_BASE    "/devices/soc.0"
 
 extern struct selabel_handle *sehandle;
 
@@ -168,7 +169,14 @@ void fixup_sys_perms(const char *upath)
     }
     if (access(buf, F_OK) == 0) {
         INFO("restorecon_recursive: %s\n", buf);
+#ifdef _PLATFORM_BASE
+        if(!strcmp(upath, DEVICES_BASE))
+            restorecon(buf);
+        else
+            restorecon_recursive(buf);
+#else
         restorecon_recursive(buf);
+#endif
     }
 }
 

--- a/init/init.c
+++ b/init/init.c
@@ -578,7 +578,7 @@ static int wait_for_coldboot_done_action(int nargs, char **args)
 {
     int ret;
     INFO("wait for %s\n", coldboot_done);
-    ret = wait_for_file(coldboot_done, COMMAND_RETRY_TIMEOUT);
+    ret = wait_for_file(coldboot_done, COLDBOOT_RETRY_TIMEOUT);
     if (ret)
         ERROR("Timed out waiting for %s\n", coldboot_done);
     return ret;

--- a/init/init.h
+++ b/init/init.h
@@ -84,6 +84,8 @@ struct svcenvinfo {
 
 #define COMMAND_RETRY_TIMEOUT 5
 
+#define COLDBOOT_RETRY_TIMEOUT 10
+
 struct service {
         /* list of all services */
     struct listnode slist;

--- a/init/util.c
+++ b/init/util.c
@@ -329,9 +329,9 @@ void sanitize(char *s)
     if (!s)
         return;
 
-    for (; *s; s++) {
+    while (*s) {
         s += strspn(s, accept);
-        if (*s) *s = '_';
+        if (*s) *s++ = '_';
     }
 }
 

--- a/init/util.c
+++ b/init/util.c
@@ -530,7 +530,11 @@ int restorecon(const char* pathname)
     return selinux_android_restorecon(pathname, 0);
 }
 
+#define RESTORECON_RECURSIVE_FLAGS \
+        (SELINUX_ANDROID_RESTORECON_FORCE | \
+        SELINUX_ANDROID_RESTORECON_RECURSE)
+
 int restorecon_recursive(const char* pathname)
 {
-    return selinux_android_restorecon(pathname, SELINUX_ANDROID_RESTORECON_RECURSE);
+    return selinux_android_restorecon(pathname, RESTORECON_RECURSIVE_FLAGS);
 }

--- a/libmincrypt/Android.mk
+++ b/libmincrypt/Android.mk
@@ -8,6 +8,13 @@ LOCAL_SRC_FILES := dsa_sig.c p256.c p256_ec.c p256_ecdsa.c rsa.c sha.c sha256.c
 LOCAL_CFLAGS := -Wall -Werror
 include $(BUILD_STATIC_LIBRARY)
 
+## Crippled version without an RSA implementation
+## to coexist with libcrypto_static and provide SHA_hash
+include $(CLEAR_VARS)
+LOCAL_MODULE := libminshacrypt
+LOCAL_SRC_FILES := sha.c sha256.c
+include $(BUILD_STATIC_LIBRARY)
+
 include $(CLEAR_VARS)
 LOCAL_MODULE := libmincrypt
 LOCAL_SRC_FILES := dsa_sig.c p256.c p256_ec.c p256_ecdsa.c rsa.c sha.c sha256.c

--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -323,6 +323,9 @@ on post-fs-data
 
     # Set SELinux security contexts on upgrade or policy update.
     restorecon_recursive /data
+    restorecon /data/data
+    restorecon /data/user
+    restorecon /data/user/0
 
     # If there is no fs-post-data action in the init.<device>.rc file, you
     # must uncomment this line, otherwise encrypted filesystems


### PR DESCRIPTION
- exec is not implemented on AOSP.
- Prevent accidentally destroying a partition of the wrong type . I had recently my data's f2fs fs corrupted and not recoverable, no idea if it linked with the double declarations of /data - for ext4 &  f2fs, where ext4 comes first.
- libminshacrypt was missing when I was building for my nexus 10 device
- fixes on restoration of selinux contexts for /Data partition and one memory corruption
